### PR TITLE
Adds Probabilistic Classifier Chain

### DIFF
--- a/skmultilearn/problem_transform/__init__.py
+++ b/skmultilearn/problem_transform/__init__.py
@@ -15,6 +15,13 @@ single-label problems: single-class or multi-class.
 | :class:`~skmultilearn.problem_transform.ClassifierChain`                    |  treats each label as a part of a conditioned  |
 |                                                                             |  chain of single-class classification problems |
 +-----------------------------------------------------------------------------+------------------------------------------------+
+| :class:`~skmultilearn.problem_transform.ProbabilisticClassifierChain`       |  extends Classifier Chains by modeling joint   |
+|                                                                             |  label distributions and estimating the        |
+|                                                                             |  probability of label sets. It trains a series |
+|                                                                             |  of classifiers, each predicting the           |
+|                                                                             |  probability of a label, conditioned on the    |
+|                                                                             |  input features and preceding label predictions|
++-----------------------------------------------------------------------------+------------------------------------------------+
 | :class:`~skmultilearn.problem_transform.ClassificationHeterogeneousFeature` | augments the feature set                       |
 |                                                                             | with extra features derived from label         |
 |                                                                             | probabilities and resolves cyclic dependencies |
@@ -34,10 +41,12 @@ single-label problems: single-class or multi-class.
 |                                                                             | properties. It searches for optimal classifiers|
 |                                                                             | with fine-tuned parameters for each label.     |
 +-----------------------------------------------------------------------------+------------------------------------------------+
+
 """
 
 from .br import BinaryRelevance
 from .cc import ClassifierChain
+from .pcc import ProbabilisticClassifierChain
 from .chf import ClassificationHeterogeneousFeature
 from .gsc import StructuredGridSearchCV
 from .lp import LabelPowerset
@@ -47,6 +56,7 @@ from .iblr import InstanceBasedLogisticRegression
 __all__ = [
     "BinaryRelevance",
     "ClassifierChain",
+    "ProbabilisticClassifierChain",
     "ClassificationHeterogeneousFeature",
     "LabelPowerset",
     "InstanceBasedLogisticRegression",

--- a/skmultilearn/problem_transform/br.py
+++ b/skmultilearn/problem_transform/br.py
@@ -46,7 +46,6 @@ class BinaryRelevance(ProblemTransformationBase):
     An example use case for Binary Relevance classification
     with an :class:`sklearn.svm.SVC` base classifier which supports sparse input:
 
-
     .. code-block:: python
 
         from skmultilearn.problem_transform import BinaryRelevance
@@ -89,7 +88,6 @@ class BinaryRelevance(ProblemTransformationBase):
                 'classifier__kernel': ['rbf', 'linear'],
             },
         ]
-
 
         clf = GridSearchCV(BinaryRelevance(), parameters, scoring='accuracy')
         clf.fit(x, y)

--- a/skmultilearn/problem_transform/cc.py
+++ b/skmultilearn/problem_transform/cc.py
@@ -31,13 +31,10 @@ class ClassifierChain(ProblemTransformationBase):
     order : List[int], permutation of ``range(n_labels)``, optional
         the order in which the chain should go through labels, the default is ``range(n_labels)``
 
-
     Attributes
     ----------
     classifiers_ : List[:class:`~sklearn.base.BaseEstimator`] of shape `n_labels`
         list of classifiers trained per partition, set in :meth:`fit`
-
-
 
     References
     ----------

--- a/skmultilearn/problem_transform/cc.py
+++ b/skmultilearn/problem_transform/cc.py
@@ -115,7 +115,7 @@ class ClassifierChain(ProblemTransformationBase):
         self.order = order
         self.copyable_attrs = ["classifier", "require_dense", "order"]
 
-    def fit(self, X, y, order=None):
+    def fit(self, X, y):
         """Fits classifier to training data
 
         Parameters

--- a/skmultilearn/problem_transform/pcc.py
+++ b/skmultilearn/problem_transform/pcc.py
@@ -1,0 +1,219 @@
+import numpy as np
+from scipy.sparse import csr_matrix, hstack
+from sklearn.base import clone
+from sklearn.utils import validation
+from sklearn.exceptions import NotFittedError
+from ..problem_transform import ClassifierChain
+
+
+class ProbabilisticClassifierChain(ClassifierChain):
+    """
+    Probabilistic Classifier Chain for Multi-Label Classification
+
+    This class implements a Probabilistic Classifier Chain (PCC), an extension of 
+    Jesse Read's Classifier Chains. It learns a chain of classifiers, each predicting 
+    a label conditioned on the input features and the predictions of preceding classifiers 
+    in the chain. This approach models joint label distributions to capture label correlations.
+
+    Each classifier in the chain is trained on an augmented input space that includes the 
+    original features (X) and the predictions of all previous classifiers in the chain.
+
+    The implementation adapted and changed from:
+    https://github.com/ChristianSch/skml/blob/master/skml/problem_transformation/probabilistic_classifier_chain.py
+
+    Parameters
+    ----------
+    classifier : :class:`~sklearn.base.BaseEstimator`
+        A scikit-learn compatible base classifier. This classifier is used as the base model
+        for each step in the classifier chain.
+    require_dense : [bool, bool], optional
+        Indicates whether the base classifier requires dense representations for input features 
+        and label matrices in fit/predict. If not provided, it defaults to using sparse 
+        representations unless the base classifier is an instance of 
+        :class:`~skmultilearn.base.MLClassifierBase`, in which case dense representations are used.
+    order : List[int], permutation of ``range(n_labels)``, optional
+        the order in which the chain should go through labels, the default is ``range(n_labels)``
+
+    Attributes
+    ----------
+    classifiers_ : List[:class:`~sklearn.base.BaseEstimator`] of shape `n_labels`
+        A list of classifiers, one for each label, trained per partition as per the chain order.
+
+    References
+    ----------
+    If using this implementation, please cite the scikit-multilearn library and the relevant paper:
+
+    .. code-block:: bibtex
+
+        @inproceedings{Dembczynski2010BayesOM,
+          title={Bayes Optimal Multilabel Classification via Probabilistic Classifier Chains},
+          author={Krzysztof Dembczynski and Weiwei Cheng and Eyke H{\"u}llermeier},
+          booktitle={International Conference on Machine Learning},
+          year={2010},
+          url={https://api.semanticscholar.org/CorpusID:6418797}
+        }
+
+    Examples
+    --------
+    An example of using Probabilistic Classifier Chain with an :class:`sklearn.svm.SVC`:
+
+    .. code-block:: python
+
+        from skmultilearn.problem_transform import ProbabilisticClassifierChain
+        from sklearn.svm import SVC
+
+        # Initialize Probabilistic Classifier Chain with an SVM classifier
+        classifier = ProbabilisticClassifierChain(
+            classifier = SVC(probability=True),
+            require_dense = [False, True]
+        )
+
+        # Train
+        classifier.fit(X_train, y_train)
+
+        # Predict
+        predictions = classifier.predict(X_test)
+
+    To optimize the classifier chain with grid search, one can vary both the base classifier
+    and its parameters:
+
+    .. code-block:: python
+
+        from skmultilearn.problem_transform import ProbabilisticClassifierChain
+        from sklearn.model_selection import GridSearchCV
+        from sklearn.naive_bayes import MultinomialNB
+        from sklearn.svm import SVC
+
+        parameters = [
+            {
+                'classifier': [MultinomialNB()],
+                'classifier__alpha': [0.7, 1.0],
+            },
+            {
+                'classifier': [SVC(probability=True)],
+                'classifier__kernel': ['rbf', 'linear'],
+            },
+        ]
+
+        clf = GridSearchCV(ProbabilisticClassifierChain(), parameters, scoring='accuracy')
+        clf.fit(X, y)
+
+        print(clf.best_params_, clf.best_score_)
+
+    """
+
+    def __init__(self, classifier=None, require_dense=None, order=None):
+        super(ProbabilisticClassifierChain, self).__init__(classifier, require_dense)
+        self.order = order
+        self.copyable_attrs = ["classifier", "require_dense", "order"]
+
+    def predict(self, X):
+        """Predict labels for X
+
+        Parameters
+        ----------
+        X : `array_like`, :class:`numpy.matrix` or :mod:`scipy.sparse` matrix, shape=(n_samples, n_features)
+            input feature matrix
+
+        Returns
+        -------
+        :mod:`scipy.sparse` matrix of `{0, 1}`, shape=(n_samples, n_labels)
+            binary indicator matrix with label assignments
+        """
+        validation.check_is_fitted(self, 'classifiers_')
+        X_extended = self._ensure_input_format(
+            X, sparse_format="csc", enforce_sparse=True
+        )
+
+        y_pred = []
+        N_instances = X_extended.shape[0]
+
+        for n in range(N_instances):
+            x = X_extended[n].reshape(1, -1)
+            y_out = None
+            p_max = 0
+
+            for b in range(2 ** self._label_count):
+                p = np.zeros((1, self._label_count))
+                y = np.array(list(map(int, np.binary_repr(b, width=self._label_count))))
+
+                for i, c in enumerate(self.classifiers_):
+                    if i == 0:
+                        p[0, i] = c.predict_proba(self._ensure_input_format(x))[0][y[i]]
+                    else:
+                        y_slice = csr_matrix(y[:i].reshape(1, -1))
+                        stacked = hstack((x, y_slice)).reshape(1, -1)
+                        p[0, i] = c.predict_proba(self._ensure_input_format(stacked))[0][y[i]]
+
+                pp = np.prod(p)
+
+                if pp > p_max:
+                    y_out = y
+                    p_max = pp
+
+            y_pred.append(y_out)
+
+        return csr_matrix(y_pred)
+
+    def predict_proba(self, X):
+        """Predict probabilities of label assignments for X
+
+        Parameters
+        ----------
+        X : `array_like`, :class:`numpy.matrix` or :mod:`scipy.sparse` matrix, shape=(n_samples, n_features)
+            input feature matrix
+
+        Returns
+        -------
+        :mod:`scipy.sparse` matrix of `float in [0.0, 1.0]`, shape=(n_samples, n_labels)
+            matrix with label assignment probabilities
+        """
+        validation.check_is_fitted(self, 'classifiers_')
+        X_extended = self._ensure_input_format(
+            X, sparse_format="csc", enforce_sparse=True
+        )
+
+        results = []
+        N_instances = X_extended.shape[0]
+
+        for n in range(N_instances):
+            x = X_extended[n].reshape(1, -1)
+            y_out = None
+            p_max = 0
+
+            for b in range(2 ** self._label_count):
+                p = np.zeros((1, self._label_count))
+                y = np.array(list(map(int, np.binary_repr(b, width=self._label_count))))
+
+                for i, c in enumerate(self.classifiers_):
+                    if i == 0:
+                        p[0, i] = c.predict_proba(self._ensure_input_format(x))[0][y[i]]
+                    else:
+                        y_slice = csr_matrix(y[:i].reshape(1, -1))
+                        stacked = hstack((x, y_slice)).reshape(1, -1)
+                        p[0, i] = c.predict_proba(self._ensure_input_format(stacked))[0][y[i]]
+
+
+                pp = np.prod(p)
+
+                if pp > p_max:
+                    y_out = csr_matrix(p)
+                    p_max = pp
+
+            results.append(y_out)
+
+        y_proba = hstack(results)
+        return self._revert_order(y_proba)
+
+    def _order(self):
+        if self.order is not None:
+            return self.order
+
+        try:
+            return list(range(self._label_count))
+        except AttributeError:
+            raise NotFittedError("This Classifier Chain has not been fit yet")
+
+    def _revert_order(self, y):
+        original_col_order = [self._order().index(x) for x in range(self._label_count)]
+        return y[:, original_col_order]

--- a/skmultilearn/problem_transform/pcc.py
+++ b/skmultilearn/problem_transform/pcc.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import csr_matrix, hstack
+from scipy.sparse import csr_matrix, hstack, vstack
 from sklearn.base import clone
 from sklearn.utils import validation
 from sklearn.exceptions import NotFittedError
@@ -190,9 +190,8 @@ class ProbabilisticClassifierChain(ClassifierChain):
                         p[0, i] = c.predict_proba(self._ensure_input_format(x))[0][y[i]]
                     else:
                         y_slice = csr_matrix(y[:i].reshape(1, -1))
-                        stacked = hstack((x, y_slice)).reshape(1, -1)
+                        stacked = hstack([x, y_slice]).reshape(1, -1)
                         p[0, i] = c.predict_proba(self._ensure_input_format(stacked))[0][y[i]]
-
 
                 pp = np.prod(p)
 
@@ -202,18 +201,5 @@ class ProbabilisticClassifierChain(ClassifierChain):
 
             results.append(y_out)
 
-        y_proba = hstack(results)
-        return self._revert_order(y_proba)
-
-    def _order(self):
-        if self.order is not None:
-            return self.order
-
-        try:
-            return list(range(self._label_count))
-        except AttributeError:
-            raise NotFittedError("This Classifier Chain has not been fit yet")
-
-    def _revert_order(self, y):
-        original_col_order = [self._order().index(x) for x in range(self._label_count)]
-        return y[:, original_col_order]
+        y_proba = vstack(results)
+        return y_proba

--- a/skmultilearn/problem_transform/tests/test_pcc.py
+++ b/skmultilearn/problem_transform/tests/test_pcc.py
@@ -12,12 +12,14 @@ class PCCTest(ClassifierBaseTest):
         )
 
         self.assertClassifierWorksWithSparsity(classifier, "sparse")
+        self.assertClassifierPredictsProbabilities(classifier, "sparse")
 
     def test_if_dense_classification_works_on_non_dense_base_classifier(self):
         classifier = ProbabilisticClassifierChain(
             classifier=SVC(probability=True), require_dense=[False, True]
         )
 
+        self.assertClassifierWorksWithSparsity(classifier, "dense")
         self.assertClassifierWorksWithSparsity(classifier, "dense")
 
     def test_if_sparse_classification_works_on_dense_base_classifier(self):
@@ -26,12 +28,14 @@ class PCCTest(ClassifierBaseTest):
         )
 
         self.assertClassifierWorksWithSparsity(classifier, "sparse")
+        self.assertClassifierPredictsProbabilities(classifier, "sparse")
 
     def test_if_dense_classification_works_on_dense_base_classifier(self):
         classifier = ProbabilisticClassifierChain(
             classifier=GaussianNB(), require_dense=[True, True]
         )
 
+        self.assertClassifierWorksWithSparsity(classifier, "dense")
         self.assertClassifierWorksWithSparsity(classifier, "dense")
 
     def test_if_works_with_cross_validation(self):

--- a/skmultilearn/problem_transform/tests/test_pcc.py
+++ b/skmultilearn/problem_transform/tests/test_pcc.py
@@ -1,0 +1,46 @@
+import unittest
+from sklearn.naive_bayes import GaussianNB
+from sklearn.svm import SVC
+
+from skmultilearn.problem_transform import ProbabilisticClassifierChain
+from skmultilearn.tests.classifier_basetest import ClassifierBaseTest
+
+class PCCTest(ClassifierBaseTest):
+    def test_if_sparse_classification_works_on_non_dense_base_classifier(self):
+        classifier = ProbabilisticClassifierChain(
+            classifier=SVC(probability=True), require_dense=[False, True]
+        )
+
+        self.assertClassifierWorksWithSparsity(classifier, "sparse")
+
+    def test_if_dense_classification_works_on_non_dense_base_classifier(self):
+        classifier = ProbabilisticClassifierChain(
+            classifier=SVC(probability=True), require_dense=[False, True]
+        )
+
+        self.assertClassifierWorksWithSparsity(classifier, "dense")
+
+    def test_if_sparse_classification_works_on_dense_base_classifier(self):
+        classifier = ProbabilisticClassifierChain(
+            classifier=GaussianNB(), require_dense=[True, True]
+        )
+
+        self.assertClassifierWorksWithSparsity(classifier, "sparse")
+
+    def test_if_dense_classification_works_on_dense_base_classifier(self):
+        classifier = ProbabilisticClassifierChain(
+            classifier=GaussianNB(), require_dense=[True, True]
+        )
+
+        self.assertClassifierWorksWithSparsity(classifier, "dense")
+
+    def test_if_works_with_cross_validation(self):
+        classifier = ProbabilisticClassifierChain(
+            classifier=GaussianNB(), require_dense=[True, True]
+        )
+
+        self.assertClassifierWorksWithCV(classifier)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Modified from https://github.com/ChristianSch/skml/blob/master/skml/problem_transformation/probabilistic_classifier_chain.py

I have to fix/add new tests. Due to the nature of PCC:s predict_proba, we cannot use the regular probability tests.

Edit: The tests work fine. The predict_proba function formatted the output incorrectly. So the issue has now been fixed.