### PR TITLE
iterative_train_test_split fix

### DIFF
--- a/docs/_static/example_usage.html
+++ b/docs/_static/example_usage.html
@@ -14598,9 +14598,8 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-InputArea jp-Cell-inputArea"><div class="jp-InputPrompt jp-InputArea-prompt">
 </div><div class="jp-RenderedHTMLCommon jp-RenderedMarkdown jp-MarkdownOutput " data-mime-type="text/markdown">
 <center>
-<h1 id="Example-usage-of-scikit-multilearn-ng">Example usage of <code>scikit-multilearn-ng</code><a class="anchor-link" href="#Example-usage-of-scikit-multilearn-ng">&#182;</a></h1><p style="text-align: center"><a href="https://scikit-multilearn-ng.github.io/scikit-multilearn-ng/">Homepage</a> | <a href="https://github.com/scikit-multilearn-ng/scikit-multilearn-ng/">GitHub</a> | <a href="https://pypi.org/project/scikit-multilearn-ng/">PyPi</a></p>
+<h1 id="Example-usage-of-scikit-multilearn-ng">Example usage of <code>scikit-multilearn-ng</code><a class="anchor-link" href="#Example-usage-of-scikit-multilearn-ng">¶</a></h1><p style="text-align: center"><a href="https://scikit-multilearn-ng.github.io/scikit-multilearn-ng/">Homepage</a> | <a href="https://github.com/scikit-multilearn-ng/scikit-multilearn-ng/">GitHub</a> | <a href="https://pypi.org/project/scikit-multilearn-ng/">PyPi</a></p>
 </center>
-<p>After a short introduction to multilabel data and multilabel classification, we will go through some examples.</p>
 <h2 id="Introduction-to-multilabel-classification">Introduction to multilabel classification<a class="anchor-link" href="#Introduction-to-multilabel-classification">&#182;</a></h2><p>In this section you will learn the basic concepts behind multi-label classification.</p>
 <h3 id="What-is-multilabel-data?">What is multilabel data?<a class="anchor-link" href="#What-is-multilabel-data?">&#182;</a></h3><p><strong>TLDR:</strong> Multilabel data is a type of data where each sample can belong to multiple classes. For example, in the case of a movie, it can belong to multiple genres, such as &quot;action&quot; and &quot;comedy&quot;. In the case of a news article, it can belong to multiple topics, such as &quot;politics&quot; and &quot;sports&quot;.</p>
 <h4 id="Whole-description:">Whole description:<a class="anchor-link" href="#Whole-description:">&#182;</a></h4><p><code>scikit-multilearn-ng</code> expects on input:</p>
@@ -14618,7 +14617,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[9]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[1]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">skmultilearn.dataset</span> <span class="kn">import</span> <span class="n">load_dataset</span>
@@ -14721,7 +14720,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[18]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[3]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">sklearn.model_selection</span> <span class="kn">import</span> <span class="n">train_test_split</span>
@@ -14744,7 +14743,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[18]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[3]:</div>
 
 
 
@@ -14777,13 +14776,12 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[17]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[4]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">import</span> <span class="nn">pandas</span> <span class="k">as</span> <span class="nn">pd</span>
-<span class="kn">from</span> <span class="nn">skmultilearn.model_selection</span> <span class="kn">import</span> <span class="n">iterative_train_test_split</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">skmultilearn.model_selection</span> <span class="kn">import</span> <span class="n">iterative_train_test_split</span>
 
-<span class="n">X_train</span><span class="p">,</span> <span class="n">y_train</span><span class="p">,</span> <span class="n">X_test</span><span class="p">,</span> <span class="n">y_test</span> <span class="o">=</span> <span class="n">iterative_train_test_split</span><span class="p">(</span><span class="n">pd</span><span class="o">.</span><span class="n">DataFrame</span><span class="o">.</span><span class="n">sparse</span><span class="o">.</span><span class="n">from_spmatrix</span><span class="p">(</span><span class="n">X</span><span class="p">),</span> <span class="n">pd</span><span class="o">.</span><span class="n">DataFrame</span><span class="o">.</span><span class="n">sparse</span><span class="o">.</span><span class="n">from_spmatrix</span><span class="p">(</span><span class="n">y</span><span class="p">),</span> <span class="n">test_size</span> <span class="o">=</span> <span class="mf">0.5</span><span class="p">)</span>
+<span class="n">X_train</span><span class="p">,</span> <span class="n">X_test</span><span class="p">,</span> <span class="n">y_train</span><span class="p">,</span> <span class="n">y_test</span> <span class="o">=</span> <span class="n">iterative_train_test_split</span><span class="p">(</span><span class="n">X</span><span class="p">,</span> <span class="n">y</span><span class="p">,</span> <span class="n">test_size</span> <span class="o">=</span> <span class="mf">0.5</span><span class="p">)</span>
 <span class="n">X_train</span><span class="o">.</span><span class="n">shape</span><span class="p">,</span> <span class="n">X_test</span><span class="o">.</span><span class="n">shape</span>
 </pre></div>
 
@@ -14800,13 +14798,13 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[17]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[4]:</div>
 
 
 
 
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>((199, 72), (199, 6))</pre>
+<pre>((191, 72), (200, 72))</pre>
 </div>
 
 </div>
@@ -14831,7 +14829,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[44]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[5]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">skmultilearn.problem_transform</span> <span class="kn">import</span> <span class="n">BinaryRelevance</span>
@@ -14867,13 +14865,13 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[44]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[5]:</div>
 
 
 
 
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>&lt;196x6 sparse matrix of type &#39;&lt;class &#39;numpy.int64&#39;&gt;&#39;
+<pre>&lt;200x6 sparse matrix of type &#39;&lt;class &#39;numpy.int64&#39;&gt;&#39;
 	with 487 stored elements in Compressed Sparse Column format&gt;</pre>
 </div>
 
@@ -14900,7 +14898,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[28]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[6]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">sklearn.metrics</span> <span class="kn">import</span> <span class="n">accuracy_score</span><span class="p">,</span> <span class="n">f1_score</span><span class="p">,</span> <span class="n">recall_score</span>
@@ -14922,13 +14920,13 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[28]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[6]:</div>
 
 
 
 
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>(0.6206393664246208, 0.1989795918367347, 0.7301136363636364)</pre>
+<pre>(0.6470091169076729, 0.195, 0.7605633802816901)</pre>
 </div>
 
 </div>
@@ -14954,7 +14952,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[34]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[7]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">skmultilearn.adapt</span> <span class="kn">import</span> <span class="n">MLkNN</span>
@@ -14986,13 +14984,13 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[34]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[7]:</div>
 
 
 
 
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>(0.433060026188584, 0.17346938775510204, 0.38920454545454547)</pre>
+<pre>(0.4039511287404211, 0.115, 0.3492957746478873)</pre>
 </div>
 
 </div>
@@ -15018,7 +15016,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[36]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[8]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">sklearn.model_selection</span> <span class="kn">import</span> <span class="n">GridSearchCV</span>
@@ -15046,7 +15044,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[36]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[8]:</div>
 
 
 
@@ -15078,7 +15076,7 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-Collapser jp-InputCollapser jp-Cell-inputCollapser">
 </div>
 <div class="jp-InputArea jp-Cell-inputArea">
-<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[41]:</div>
+<div class="jp-InputPrompt jp-InputArea-prompt">In&nbsp;[9]:</div>
 <div class="jp-CodeMirrorEditor jp-Editor jp-InputArea-editor" data-type="inline">
      <div class="CodeMirror cm-s-jupyter">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">skmultilearn.problem_transform</span> <span class="kn">import</span> <span class="n">ClassifierChain</span>
@@ -15113,13 +15111,13 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <div class="jp-OutputArea jp-Cell-outputArea">
 <div class="jp-OutputArea-child jp-OutputArea-executeResult">
     
-    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[41]:</div>
+    <div class="jp-OutputPrompt jp-OutputArea-prompt">Out[9]:</div>
 
 
 
 
 <div class="jp-RenderedText jp-OutputArea-output jp-OutputArea-executeResult" data-mime-type="text/plain">
-<pre>(0.6189938435198434, 0.20918367346938777, 0.7073863636363636)</pre>
+<pre>(0.6484772423333367, 0.24, 0.7352112676056338)</pre>
 </div>
 
 </div>

--- a/skmultilearn/model_selection/iterative_stratification.py
+++ b/skmultilearn/model_selection/iterative_stratification.py
@@ -76,7 +76,13 @@ import itertools
 from sklearn.utils import check_random_state
 
 
-def iterative_train_test_split(X: np.ndarray, y: np.ndarray, test_size: float, random_state = None, shuffle: bool = False):
+def iterative_train_test_split(
+    X: np.ndarray,
+    y: np.ndarray,
+    test_size: float,
+    random_state=None,
+    shuffle: bool = False,
+):
     """Iteratively stratified train/test split
 
     Parameters

--- a/skmultilearn/model_selection/iterative_stratification.py
+++ b/skmultilearn/model_selection/iterative_stratification.py
@@ -76,11 +76,15 @@ import itertools
 from sklearn.utils import check_random_state
 
 
-def iterative_train_test_split(X, y, test_size, random_state=None, shuffle=False):
+def iterative_train_test_split(X: np.ndarray, y: np.ndarray, test_size: float, random_state = None, shuffle: bool = False):
     """Iteratively stratified train/test split
 
     Parameters
     ----------
+    X : np.ndarray
+        input features
+    y : np.ndarray
+        input labels
     test_size : float, [0,1]
         the proportion of the dataset to include in the test split, the rest will be put in the train set
     random_state : None | int | np.random.RandomState

--- a/skmultilearn/model_selection/iterative_stratification.py
+++ b/skmultilearn/model_selection/iterative_stratification.py
@@ -105,8 +105,8 @@ def iterative_train_test_split(X, y, test_size, random_state=None, shuffle=False
 
     train_indexes, test_indexes = next(stratifier.split(X, y))
 
-    X_train, y_train = X.loc[train_indexes], y.loc[train_indexes]
-    X_test, y_test = X.loc[test_indexes], y.loc[test_indexes]
+    X_train, y_train = X[train_indexes, :], y[train_indexes, :]
+    X_test, y_test = X[test_indexes, :], y[test_indexes, :]
 
     return X_train, X_test, y_train, y_test
 


### PR DESCRIPTION
I've used scikit-multilearn and I've met problem with random_state within IterativeStratification, that caused me to switch to scikit-multilearn-ng. After switching to scikit-multilearn-ng, I ran same pipeline and noticed that in the original version iterative_train_test_split uses np arrays in comparison to ng which uses pandas. I propose to switch to original numpy implementation, because that will not cause troubles to new users that switch to ng library and will use same code, which they used with original version, and also it is more intuitively likely that X, y should be np.arrays, not pandas DataFrames. Also in the original documenatation that is also available from scikit-multilearn pipy page, there is following implementation of train_test_split with np arrays.