### PR TITLE
Fix typo in comment to match actual return value (#25)

### DIFF
--- a/skmultilearn/model_selection/iterative_stratification.py
+++ b/skmultilearn/model_selection/iterative_stratification.py
@@ -101,7 +101,7 @@ def iterative_train_test_split(
 
     Returns
     -------
-    X_train, y_train, X_test, y_test
+    X_train, X_test, y_train, y_test
         stratified division into train/test split
     """
 


### PR DESCRIPTION
This closes #25. One line change in the comment of `iterative_train_test_split` to make the comment match the actual return order.